### PR TITLE
Update Readme, add language specific options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,22 @@ Once `clang` is installed, you must ensure it is in your system PATH so that Sub
 |:------|:----------|
 |include_dirs|A list of directories to be added to the header search paths (-I is not needed).|
 |extra_flags|A string with extra flags to pass to clang. These should be used carefully, as they may cause linting to fail.|
+|extra_cflags|Extra flags to pass to clang when linting C syntax code.|
+|extra_cxxflags|Extra flags to pass to clang when linting C++ syntax code.|
 
-In project-specific settings, '$project_folder' or '${project_folder}' can be used to specify relative path.
+In project-specific settings, SublimeLinter allows [expansion variables](http://sublimelinter.readthedocs.io/en/latest/settings.html#settings-expansion). For example, in project-specific settings, '${project_path}' can be used to specify a path relative to the project folder.
 ```
 "SublimeLinter":
 {
     "linters":
     {
         "clang": {
-            "extra_flags": "-Wall -I${project_folder}/foo",
+            "extra_cflags": "-std=c99",
+            "extra_cxxflags": "-std=c++11",
+            "extra_flags": "-Wall -I${project_path}/foo",
             "include_dirs": [
-                "${project_folder}/3rdparty/bar/include",
-                "${project_folder}/3rdparty/baz"
+                "${project_path}/3rdparty/bar/include",
+                "${project_path}/3rdparty/baz"
             ]
         }
     }

--- a/linter.py
+++ b/linter.py
@@ -12,9 +12,6 @@
 
 import shlex
 from SublimeLinter.lint import Linter, util
-import sublime
-import os
-import string
 
 
 class Clang(Linter):
@@ -37,7 +34,9 @@ class Clang(Linter):
 
     defaults = {
         'include_dirs': [],
-        'extra_flags': ""
+        'extra_flags': "",
+        'extra_cflags': "",
+        'extra_cxxflags': ""
     }
 
     base_cmd = (
@@ -55,13 +54,13 @@ class Clang(Linter):
         """
 
         result = self.base_cmd
+        settings = self.get_view_settings()
 
         if util.get_syntax(self.view) in ['c', 'c improved']:
-            result += ' -x c '
+            result += ' -x c ' + settings.get('extra_cflags', '') + ' '
         elif util.get_syntax(self.view) in ['c++', 'c++11']:
-            result += ' -x c++ '
+            result += ' -x c++ ' + settings.get('extra_cxxflags', '') + ' '
 
-        settings = self.get_view_settings()
         result += settings.get('extra_flags', '')
 
         include_dirs = settings.get('include_dirs', [])


### PR DESCRIPTION
Changed Readme to reflect removal of "project_folder" expansion variable and replaced it with "project_path" with reference to SublimeLinter documentation.
Added 'extra_cflags' and 'extra_cxxflags' settings for c and c++ specific options.