### PR TITLE
Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ We have two settings sections. 'clang' for c files, and 'clang++' to configure t
 },
 ```
 
+Note: 'args' has the default value '-Wall -fsyntax-only -fno-caret-diagnostics', so make sure to include them when overriding 'args'.
+
 All common settings information can be found here:
 
 - SublimeLinter settings: http://sublimelinter.com/en/latest/settings.html

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Additional settings for SublimeLinter-clang:
 |Setting|Description|
 |:------|:----------|
 |I|A list of directories to be added to the header search paths.|
-|Wall|'Wall' is set by default, set this to false to omit it|
 |x|Automatically set depending on the file type.|
 
 SublimeLinter allows [expansion variables](http://sublimelinter.readthedocs.io/en/latest/settings.html#settings-expansion). For example, '${folder}' can be used to specify a path relative to the project folder.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,29 @@ Once `clang` is installed, ensure it is in your system PATH so that SublimeLinte
 The docs cover [troubleshooting PATH configuration](http://sublimelinter.com/en/latest/troubleshooting.html#finding-a-linter-executable)
 
 ## Settings
+
+We have two settings sections. 'clang' for c files, and 'clang++' to configure the linter for c++ files. E.g.
+
+```
+{
+    "linters":
+    {
+        "clang": {
+            "args": "-fvery-important",
+            "I": [
+                "${folder}/3rdparty/bar/include",
+                "${folder}/3rdparty/baz"
+            ]
+        },
+        "clang++": {
+            "args": "-falso-important"
+        }
+    }
+},
+```
+
+All common settings information can be found here:
+
 - SublimeLinter settings: http://sublimelinter.com/en/latest/settings.html
 - Linter settings: http://sublimelinter.com/en/latest/linter_settings.html
 
@@ -25,25 +48,11 @@ Additional settings for SublimeLinter-clang:
 
 |Setting|Description|
 |:------|:----------|
-|include_dirs|A list of directories to be added to the header search paths (-I is not needed).|
-|extra_flags|A string with extra flags to pass to clang. These should be used carefully, as they may cause linting to fail.|
+|I|A list of directories to be added to the header search paths.|
+|Wall|'Wall' is set by default, set this to false to omit it|
+|x|Automatically set depending on the file type.|
 
-In project-specific settings, SublimeLinter allows [expansion variables](http://sublimelinter.readthedocs.io/en/latest/settings.html#settings-expansion). For example, in project-specific settings, '${project_path}' can be used to specify a path relative to the project folder.
-```
-"SublimeLinter":
-{
-    "linters":
-    {
-        "clang": {
-            "extra_flags": "-Wall -I${project_path}/foo",
-            "include_dirs": [
-                "${project_path}/3rdparty/bar/include",
-                "${project_path}/3rdparty/baz"
-            ]
-        }
-    }
-},
-```
+SublimeLinter allows [expansion variables](http://sublimelinter.readthedocs.io/en/latest/settings.html#settings-expansion). For example, '${folder}' can be used to specify a path relative to the project folder.
 
 ## Troubleshooting
 C/C++ linting is not always straightforward. A few things to try when there's (almost) no linting information available:
@@ -51,5 +60,5 @@ C/C++ linting is not always straightforward. A few things to try when there's (a
 - The linter might be missing some header files. They can be added with "include_dirs".
 - Sometimes clang fails to locate the C++ standard library headers.
 Assuming the compilation works when executed via command line, try to compile with `clang++ -v`.
-This will display all of the hidden flags clang uses. As a last resort, they can all be added as "extra_flags".
+This will display all of the hidden flags clang uses. As a last resort, they can all be added as "args".
 

--- a/linter.py
+++ b/linter.py
@@ -27,10 +27,10 @@ OUTPUT_RE = re.compile(
 
 
 class Clang(Linter):
-    cmd = 'clang -fsyntax-only -fno-caret-diagnostics ${args} -'
+    cmd = 'clang ${args} -'
     defaults = {
         'selector': 'source.c',
-        '-Wall': True,
+        'args': '-Wall -fsyntax-only -fno-caret-diagnostics',
         '-I +': [],
         '-x': 'c'
     }
@@ -41,10 +41,10 @@ class Clang(Linter):
 
 class ClangPlus(Linter):
     name = 'clang++'
-    cmd = 'clang -fsyntax-only -fno-caret-diagnostics ${args} -'
+    cmd = 'clang ${args} -'
     defaults = {
         'selector': 'source.c++',
-        '-Wall': True,
+        'args': '-Wall -fsyntax-only -fno-caret-diagnostics',
         '-I +': [],
         '-x': 'c++'
     }

--- a/linter.py
+++ b/linter.py
@@ -10,46 +10,43 @@
 
 """This module exports the Clang plugin class."""
 
-from SublimeLinter.lint import Linter, util
+import re
+from SublimeLinter.lint import Linter
 
 
-class Clang(Linter):
-    """Provides an interface to clang."""
+OUTPUT_RE = re.compile(
+    r'<stdin>:(?P<line>\d+):'
+    r'((?P<col>\d*): )?'  # column number, colon and space are only applicable for single line messages
+    # several lines of anything followed by
+    # either error/warning/note or newline (= irrelevant backtrace content)
+    # (lazy quantifiers so we don’t skip what we seek)
+    r'(.*?((?P<error>error)|(?P<warning>warning|note)|\r?\n))+?'
+    r': (?P<message>.+)',  # match the remaining content of the current line for output
+    re.MULTILINE
+)
 
-    regex = (
-        r'<stdin>:(?P<line>\d+):'
-        r'((?P<col>\d*): )?'  # column number, colon and space are only applicable for single line messages
-        # several lines of anything followed by
-        # either error/warning/note or newline (= irrelevant backtrace content)
-        # (lazy quantifiers so we don’t skip what we seek)
-        r'(.*?((?P<error>error)|(?P<warning>warning|note)|\r?\n))+?'
-        r': (?P<message>.+)'  # match the remaining content of the current line for output
-    )
 
-    multiline = True
-
+class clangc(Linter):
+    cmd = 'clang -fsyntax-only -fno-caret-diagnostics ${args} -'
     defaults = {
-        'selector': 'source.c, source.c++',
+        'selector': 'source.c',
         '-Wall': True,
         '-I +': [],
-        '-x': None
+        '-x': 'c'
     }
-
+    regex = OUTPUT_RE
+    multiline = True
     on_stderr = None
 
-    def cmd(self):
-        """Return the command line to execute."""
 
-        cmd = 'clang -fsyntax-only -fno-caret-diagnostics ${args} -'
-
-        settings = self.get_view_settings()
-
-        # If not set by the user apply magic
-        if settings['x'] is None:
-            syntax = util.get_syntax(self.view)
-            if syntax in ['c', 'c improved']:
-                settings['x'] = 'c'
-            elif syntax in ['c++', 'c++11']:
-                settings['x'] = 'c++'
-
-        return cmd
+class clangcplus(Linter):
+    cmd = 'clang -fsyntax-only -fno-caret-diagnostics ${args} -'
+    defaults = {
+        'selector': 'source.c++',
+        '-Wall': True,
+        '-I +': [],
+        '-x': 'c++'
+    }
+    regex = OUTPUT_RE
+    multiline = True
+    on_stderr = None

--- a/linter.py
+++ b/linter.py
@@ -26,7 +26,7 @@ OUTPUT_RE = re.compile(
 )
 
 
-class clangc(Linter):
+class Clang(Linter):
     cmd = 'clang -fsyntax-only -fno-caret-diagnostics ${args} -'
     defaults = {
         'selector': 'source.c',
@@ -39,7 +39,8 @@ class clangc(Linter):
     on_stderr = None
 
 
-class clangcplus(Linter):
+class ClangPlus(Linter):
+    name = 'clang++'
     cmd = 'clang -fsyntax-only -fno-caret-diagnostics ${args} -'
     defaults = {
         'selector': 'source.c++',

--- a/messages.json
+++ b/messages.json
@@ -1,3 +1,4 @@
 {
-    "install": "messages/install.txt"
+    "install": "messages/install.txt",
+    "2.0.0": "messages/2.0.0.txt"
 }

--- a/messages/2.0.0.txt
+++ b/messages/2.0.0.txt
@@ -8,7 +8,8 @@ We revamped the settings, and you probably have to make changes.
   on the command line).
 
 * 'extra_flags' is now 'args' (which is the standard name in the
-  SublimeLinter world).
+  SublimeLinter world). Note that 'args' has the default value
+  '-Wall -fsyntax-only -fno-caret-diagnostics'.
 
 'c' and 'c++' files now have different settings sections.
 

--- a/messages/2.0.0.txt
+++ b/messages/2.0.0.txt
@@ -1,0 +1,24 @@
+SublimeLinter-clang 2.0.0
+-------------------------
+
+
+We revamped the settings, and you probably have to make changes.
+
+* If you used 'include_dirs', it is now called 'I' (just like the arg
+  on the command line).
+
+* 'extra_flags' is now 'args' (which is the standard name in the
+  SublimeLinter world).
+
+'c' and 'c++' files now have different settings sections.
+
+{
+    "linters": {
+        "clang": {    // <- for c files
+
+        },
+        "clang++": {  // <-  for c++ files
+
+        }
+    }
+}

--- a/messages/install.txt
+++ b/messages/install.txt
@@ -4,4 +4,4 @@ This linter plugin for SublimeLinter provides an interface to clang.
 
 Please read the installation instructions at:
 
-https://github.com/nirm03/SublimeLinter-clang
+https://github.com/SublimeLinter/SublimeLinter-clang


### PR DESCRIPTION
This is a clean version **but without deprecation code**. 

- `extra_flags` is really just our `args`
- `include_dirs` can be expressed by `-I +`
- `x` also is just a setting with a dynamic default
- `Wall` is a switch with a True default

All requires SL > 4.3

Basically saying, we don't need to reinvent the wheel here. SL really provides most of that out-of-the-box. 

(Except the `x`; maybe the defaults processor should accept callables.)