### PR TITLE
Support isystem flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Additional settings for SublimeLinter-clang:
 |Setting|Description|
 |:------|:----------|
 |I|A list of directories to be added to the header search paths.|
+|isystem|A list of directories to be added to the system header search paths.|
 |x|Automatically set depending on the file type.|
 
 SublimeLinter allows [expansion variables](http://sublimelinter.readthedocs.io/en/latest/settings.html#settings-expansion). For example, '${folder}' can be used to specify a path relative to the project folder.

--- a/linter.py
+++ b/linter.py
@@ -32,6 +32,7 @@ class Clang(Linter):
         'selector': 'source.c',
         'args': '-Wall -fsyntax-only -fno-caret-diagnostics',
         '-I +': [],
+        '-isystem +': [],
         '-x': 'c'
     }
     regex = OUTPUT_RE
@@ -46,6 +47,7 @@ class ClangPlus(Linter):
         'selector': 'source.c++',
         'args': '-Wall -fsyntax-only -fno-caret-diagnostics',
         '-I +': [],
+        '-isystem +': [],
         '-x': 'c++'
     }
     regex = OUTPUT_RE


### PR DESCRIPTION
In addition to `-I`, this adds support for the [`-isystem` flag][-isystem flag].

The main difference between `-I` and `-isystem` is that warnings for the latter will be suppressed. This is useful when using strict warnings for linting, whilst avoiding warnings from third party headers to show up.

  [-isystem flag]: https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-isystem-directory