### PR TITLE
Add separate linters for Objective-C/Objective C++.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -53,3 +53,33 @@ class ClangPlus(Linter):
     regex = OUTPUT_RE
     multiline = True
     on_stderr = None
+
+
+class ClangObjC(Linter):
+    name = 'clang-objc'
+    cmd = 'clang ${args} -'
+    defaults = {
+        'selector': 'source.objc',
+        'args': '-Wall -fsyntax-only -fno-caret-diagnostics -fobjc-arc',
+        '-I +': [],
+        '-isystem +': [],
+        '-x': 'objective-c'
+    }
+    regex = OUTPUT_RE
+    multiline = True
+    on_stderr = None
+
+
+class ClangObjCPlus(Linter):
+    name = 'clang-objc++'
+    cmd = 'clang ${args} -'
+    defaults = {
+        'selector': 'source.objc++',
+        'args': '-Wall -fsyntax-only -fno-caret-diagnostics -fobjc-arc',
+        '-I +': [],
+        '-isystem +': [],
+        '-x': 'objective-c++'
+    }
+    regex = OUTPUT_RE
+    multiline = True
+    on_stderr = None


### PR DESCRIPTION
This adds two extra linters that apply to Objective-C/C++ code.

I have added `-fobjc-arc` as compiler arg to make the `__has_feature(objc_arc)` preprocessor test pass. Automatic reference counting (arc) should be the default in most Objective-C projects these days.

It would have been cool to add support for module imports (`@import CoreGraphics`), but unfortunately this requires more extensive command line flags that might be machine specific. So I left it out.